### PR TITLE
👷 Add GHA deployment jobs

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -51,3 +51,41 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  push_to_production:
+    if: ${{ github.ref_type == 'tag' }}
+    runs-on: ubuntu-latest
+    needs:
+      - push_to_registry
+    environment: production
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.KUBERNETES_CONFIG_REPO_ACCESS_TOKEN }}
+          repository: ppy/osu-kubernetes-config
+          event-type: scthumber-deploy
+          client-payload: '{ "dockerTag": "${{ github.ref_name }}" }'
+
+  push_to_staging:
+    if: ${{ github.ref_type == 'branch' && github.ref_name == 'master' }}
+    runs-on: ubuntu-latest
+    needs:
+      - push_to_registry
+    environment: staging
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.KUBERNETES_CONFIG_REPO_ACCESS_TOKEN }}
+          repository: ppy/osu-kubernetes-config
+          event-type: dev-ppy-sh-deploy
+          client-payload: '{ "values": { "scthumber": { "image": { "tag": "${{ github.sha }}" } } } }'


### PR DESCRIPTION
Push staging and production deployment jobs to our Kubernetes management repository, similar to `osu-web`.

Needs access to the `KUBERNETES_CONFIG_REPO_ACCESS_TOKEN` secret. Also, manual approval for production deployments should be set-up in environment settings in this repository like osu-web.